### PR TITLE
Update XCSoar to v6.8.11

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "xcsoar"]
 	path = xcsoar.submodule
-	url = git://github.com/skylines-project/XCSoar.git
+	url = git://github.com/XCSoar/XCSoar.git

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,9 @@ class XCSoarBuild(build):
         else:
             target_path = "UNIX_PYTHON"
 
-        target_files = [os.path.join(build_path, target_path, "bin", "xcsoar.so")]
+        target_files = [
+            os.path.join(build_path, target_path, "opt", "bin", "xcsoar.so")
+        ]
 
         def compile():
             call(cmd, cwd=XCSOAR_PATH)

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ class XCSoarBuild(build):
         except NotImplementedError:
             print("Unable to determine number of CPUs. Using single threaded make.")
 
-        options = ["DEBUG=n", "ENABLE_SDL=n"]
+        options = ["DEBUG=n", "ENABLE_SDL=n", "LIBJPEG=n"]
         cmd.extend(options)
 
         targets = ["python"]


### PR DESCRIPTION
This includes https://github.com/XCSoar/XCSoar/commit/0f7de0cd927daeabd3972d918e1a9e44887b5613, which fixes a case of undefined behavior in the Python `Airspaces` class when `optimise()` is called without having added any airspaces.