### PR TITLE
 CI: Explicitly set `--python-tag` and `--plat-name` options for `bdist_wheel` command 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ jobs:
 
       language: python
       python: 2.7
+      env: PYTHON_TAG=py27
 
       addons:
         apt:
@@ -33,6 +34,7 @@ jobs:
 
     - <<: *test
       python: 3.4
+      env: PYTHON_TAG=py34
 
     - stage: test
       env: NAME=black         # used only to make Travis UI show description
@@ -52,7 +54,7 @@ notifications:
 
 deploy:
   provider: pypi
-  distributions: "sdist bdist_wheel"
+  distributions: "sdist bdist_wheel --python-tag=${PYTHON_TAG}"
   skip_cleanup: true
   user: Tobias.Bieniek
   password:

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,7 @@ notifications:
 
 deploy:
   provider: pypi
-  distributions: "sdist bdist_wheel --python-tag=${PYTHON_TAG}"
+  distributions: "sdist bdist_wheel --python-tag=${PYTHON_TAG} --plat-name=linux_x86_64"
   skip_cleanup: true
   user: Tobias.Bieniek
   password:


### PR DESCRIPTION
Right now the built wheels are not limited to any particular Python version or platform by mistake. They only work for the specific major-minor version that they were built with and only on Linux. This PR changes the CI instructions to hopefully cause the right tags to be emitted.