### PR TITLE
CI: Use `name` property instead of `NAME` env var workaround

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ jobs:
       python: 3.4
 
     - stage: test
-      env: NAME=black         # used only to make Travis UI show description
+      name: "Linting (black)"
 
       language: python
       python: 3.6


### PR DESCRIPTION
TIL