### PR TITLE
CI: Run tests on Ubuntu Bionic Beaver, and Python 2.7 and 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
-dist: trusty
+dist: bionic
+
 branches:
   except:
     - /^dependabot\/.*$/

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ jobs:
         apt:
           packages:
             - libcurl4-openssl-dev
-            - python3.5-dev
+            - python-dev
 
       install:
         - pip install -r requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,10 +32,7 @@ jobs:
         - pytest -vv
 
     - <<: *test
-      python: 3.4
-
-    - <<: *test
-      python: 3.5
+      python: 3.6
 
     - stage: test
       name: "Linting (black)"


### PR DESCRIPTION
Since this is effectively dropping support for Python 3.4 and 3.5 this should probably be considered a breaking change.